### PR TITLE
Add "Mesh to Strokes" tool to allow working with original strokes 

### DIFF
--- a/UnitySDK/Assets/TiltBrush/Scripts/Editor/EditorUtils.cs
+++ b/UnitySDK/Assets/TiltBrush/Scripts/Editor/EditorUtils.cs
@@ -30,7 +30,7 @@ public class EditorUtils {
 
   #region Tilt Menu
 
-  [MenuItem("Tilt Brush/Labs/Mesh To Strokes")]
+  [MenuItem("Tilt Brush/Labs/Split mesh by stroke")]
   public static void MeshToStrokes()
   {
     GameObject[] selected = Selection.gameObjects;
@@ -41,13 +41,13 @@ public class EditorUtils {
     }
 
     Undo.IncrementCurrentGroup();
-    Undo.SetCurrentGroupName("Separate mesh to strokes");
+    Undo.SetCurrentGroupName("Split mesh by stroke");
 
     AssetDatabase.StartAssetEditing();
 
-    if (!AssetDatabase.IsValidFolder("Assets/MeshToStrokes"))
+    if (!AssetDatabase.IsValidFolder("Assets/SplitMeshByStroke"))
     {
-      AssetDatabase.CreateFolder("Assets","MeshToStrokes");
+      AssetDatabase.CreateFolder("Assets","SplitMeshByStroke");
     }
 
     bool cancel = false;
@@ -120,7 +120,7 @@ public class EditorUtils {
         List<GameObject> strokeGameObjects = new List<GameObject>();
 
         string baseNameForStrokeGameObject = go.name;
-        Undo.RecordObject(go,"Separate mesh to strokes");
+        Undo.RecordObject(go,"Split mesh by stroke");
         go.name += " (separated)";
 
         // explanation of the following 6 lines:
@@ -146,7 +146,7 @@ public class EditorUtils {
             vertexCounts.Add(uv3[i].x,1);
             strokeIDs.Add(uv3[i].x);
             GameObject strokeGameObject = GameObject.Instantiate(go);
-            Undo.RegisterCreatedObjectUndo(strokeGameObject, "Separate mesh to strokes");
+            Undo.RegisterCreatedObjectUndo(strokeGameObject, "Split mesh by stroke");
             strokeGameObjects.Add(strokeGameObject);
           }
           else

--- a/UnitySDK/Assets/TiltBrush/Scripts/Editor/EditorUtils.cs
+++ b/UnitySDK/Assets/TiltBrush/Scripts/Editor/EditorUtils.cs
@@ -91,7 +91,7 @@ public class EditorUtils {
         List<GameObject> strokeGameObjects = new List<GameObject>();
 
         string baseNameForStrokeGameObject = go.name;
-        Undo.RecordObject(go,"Separate sketch by color");
+        Undo.RecordObject(go,"Separate mesh to strokes");
         go.name += " (separated)";
 
         for (int i = 0; i < mesh.vertexCount; i++)
@@ -102,7 +102,7 @@ public class EditorUtils {
             vertexCounts.Add(uv2[i].x,1);
             strokeIDs.Add(uv2[i].x);
             GameObject strokeGameObject = GameObject.Instantiate(go, go.transform.position, go.transform.rotation);
-            Undo.RegisterCreatedObjectUndo(strokeGameObject, "Separate sketch by color");
+            Undo.RegisterCreatedObjectUndo(strokeGameObject, "Separate mesh to strokes");
             strokeGameObjects.Add(strokeGameObject);
           }
           else

--- a/UnitySDK/Assets/TiltBrush/Scripts/Editor/EditorUtils.cs
+++ b/UnitySDK/Assets/TiltBrush/Scripts/Editor/EditorUtils.cs
@@ -246,13 +246,18 @@ public class EditorUtils {
           mesh.GetUVs(1,uv2_full);
 
           NativeArray<int>.Copy(allNewTriangles, startingIndexInTrianglesArray, trianglesForStroke, 0, triangleCount);
-          Array.Copy(mesh.vertices, startingIndexInVerticesArray, vertices, 0, vertexCount);
-          Array.Copy(mesh.uv, startingIndexInVerticesArray, uv, 0, vertexCount);
-          Array.Copy(mesh.normals, startingIndexInVerticesArray, normals, 0, vertexCount);
-          Array.Copy(mesh.colors, startingIndexInVerticesArray, colors, 0, vertexCount);
-          Array.Copy(uv3.ToArray(), startingIndexInVerticesArray, uv3_subset, 0, vertexCount);
-          Array.Copy(uv2_full.ToArray(), startingIndexInVerticesArray, uv2, 0, vertexCount);
 
+          CopyMeshAttribute(mesh.vertices,vertices,startingIndexInVerticesArray,vertexCount);
+
+          CopyMeshAttribute(mesh.uv, uv, startingIndexInVerticesArray, vertexCount);
+
+          CopyMeshAttribute(mesh.normals, normals, startingIndexInVerticesArray, vertexCount);
+
+          CopyMeshAttribute(mesh.colors, colors, startingIndexInVerticesArray, vertexCount);
+
+          CopyMeshAttribute(uv2_full.ToArray(), uv2, startingIndexInVerticesArray, vertexCount);
+
+          CopyMeshAttribute(uv3.ToArray(), uv3_subset, startingIndexInVerticesArray, vertexCount);
 
           var newMesh_ = GetMeshSubset(mesh,trianglesForStroke,vertices, uv, uv2,uv3_subset,normals, colors, strokeIndex);
 
@@ -265,6 +270,21 @@ public class EditorUtils {
       }
 
       return cancel;
+  }
+
+  // copy elements from sourceArray to destinationArray starting at startingIndexInSource,
+  // making sure that bounds aren't exceeded
+  // The purpose of this function is because e.g Dots stroke has uv2, but OilPaint stroke doesn't.
+  private static void CopyMeshAttribute<T>(
+    T[] sourceArray,
+    T[] destinationArray,
+    int startingIndexInSource,
+    int vertexCount)
+  {
+    if (sourceArray != null && sourceArray.Length >= startingIndexInSource + vertexCount)
+    {
+      Array.Copy(sourceArray, startingIndexInSource, destinationArray, 0, vertexCount);
+    }
   }
 
   [MenuItem("Tilt Brush/Labs/Separate strokes by brush color")]

--- a/UnitySDK/Assets/TiltBrush/Scripts/Editor/EditorUtils.cs
+++ b/UnitySDK/Assets/TiltBrush/Scripts/Editor/EditorUtils.cs
@@ -43,22 +43,30 @@ public class EditorUtils {
     Undo.IncrementCurrentGroup();
     Undo.SetCurrentGroupName("Separate mesh to strokes");
 
+    AssetDatabase.StartAssetEditing();
+
     bool cancel = false;
-    foreach (var obj in selected)
+    try
     {
-      MeshFilter mf = obj.GetComponent<MeshFilter>();
-      MeshRenderer mr = mf.GetComponent<MeshRenderer>();
-      cancel = MeshToStroke(mf);
-      if (cancel)
+      foreach (var obj in selected)
       {
-        Undo.RevertAllInCurrentGroup();
-        break;
+        MeshFilter mf = obj.GetComponent<MeshFilter>();
+        MeshRenderer mr = mf.GetComponent<MeshRenderer>();
+        cancel = MeshToStroke(mf);
+        if (cancel)
+        {
+          Undo.RevertAllInCurrentGroup();
+          break;
+        }
+        Undo.DestroyObjectImmediate(mf);
+        Undo.DestroyObjectImmediate(mr);
       }
-      Undo.DestroyObjectImmediate(mf);
-      Undo.DestroyObjectImmediate(mr);
     }
-    AssetDatabase.Refresh();
-    EditorUtility.ClearProgressBar();
+    finally // since we call AssetDatabase.StartAssetEditing(), we must also call AssetDatabase.StopAssetEditing()
+    {
+      EditorUtility.ClearProgressBar();
+      AssetDatabase.StopAssetEditing();
+    }
   }
 
   // separate a mesh into strokes by timestamp in UV2

--- a/UnitySDK/Assets/TiltBrush/Scripts/Editor/EditorUtils.cs
+++ b/UnitySDK/Assets/TiltBrush/Scripts/Editor/EditorUtils.cs
@@ -45,6 +45,11 @@ public class EditorUtils {
 
     AssetDatabase.StartAssetEditing();
 
+    if (!AssetDatabase.IsValidFolder("Assets/MeshToStrokes"))
+    {
+      AssetDatabase.CreateFolder("Assets","MeshToStrokes");
+    }
+
     bool cancel = false;
     try
     {
@@ -188,9 +193,6 @@ public class EditorUtils {
         nativeStrokeIDs.Dispose();
         originalTriangles.Dispose();
         vertexMap.Dispose();
-
-
-        AssetDatabase.CreateFolder("Assets",$"{baseNameForStrokeGameObject}_submeshes");
 
         const int PROGRESS_FREQUENCY = 1;
         int count = 0;
@@ -373,7 +375,7 @@ public class EditorUtils {
     newMesh.colors = colors ?? OriginalMesh.colors;
     newMesh.subMeshCount = OriginalMesh.subMeshCount;
     newMesh.normals = normals ?? OriginalMesh.normals;
-    AssetDatabase.CreateAsset(newMesh, $"Assets/{OriginalMesh.name}_submeshes/{OriginalMesh.name}_submesh[{index}].asset");
+    AssetDatabase.CreateAsset(newMesh, $"Assets/MeshToStrokes/{OriginalMesh.name}_submesh[{index}].asset");
     return newMesh;
   }
 

--- a/UnitySDK/Assets/TiltBrush/Scripts/Editor/EditorUtils.cs
+++ b/UnitySDK/Assets/TiltBrush/Scripts/Editor/EditorUtils.cs
@@ -240,6 +240,7 @@ public class EditorUtils {
           Vector3[] normals = new Vector3[vertexCount];
           Color[] colors = new Color[vertexCount];
 
+
           NativeArray<int>.Copy(allNewTriangles, startingIndexInTrianglesArray, trianglesForStroke, 0, triangleCount);
           Array.Copy(mesh.vertices, startingIndexInVerticesArray, vertices, 0, vertexCount);
           Array.Copy(mesh.uv, startingIndexInVerticesArray, uv, 0, vertexCount);
@@ -247,7 +248,7 @@ public class EditorUtils {
           Array.Copy(mesh.colors, startingIndexInVerticesArray, colors, 0, vertexCount);
 
 
-          var newMesh_ = GetMeshSubset(mesh,trianglesForStroke,vertices, uv, normals, colors, strokeIndex);
+          var newMesh_ = GetMeshSubset(mesh,trianglesForStroke,vertices, uv, uv2.ToArray(),normals, colors, strokeIndex);
 
           strokeGameObject.GetComponent<MeshFilter>().mesh = newMesh_;
           strokeIndex++;
@@ -375,15 +376,21 @@ public class EditorUtils {
     return v;
   }
 
-  public static Mesh GetMeshSubset(Mesh OriginalMesh, int[] Triangles, Vector3[] vertices = null, Vector2[] uv = null, Vector3[] normals = null,
+  public static Mesh GetMeshSubset(Mesh OriginalMesh, int[] Triangles, Vector3[] vertices = null, Vector2[] uv = null, Vector3[] uv2 =  null, Vector3[] normals = null,
     Color[] colors = null, int index = 0) {
     Mesh newMesh = new Mesh();
     newMesh.name = OriginalMesh.name;
     newMesh.vertices = vertices ?? OriginalMesh.vertices;
     newMesh.triangles = Triangles;
     newMesh.uv = uv ?? OriginalMesh.uv;
-    //newMesh.uv2 = OriginalMesh.uv2; <-- not needed for now
-    // newMesh.uv3 = OriginalMesh.uv3;
+    if (uv2 != null)
+    {
+      newMesh.SetUVs(1,uv2);
+    }
+    else
+    {
+      newMesh.uv2 = OriginalMesh.uv2;
+    }
     newMesh.colors = colors ?? OriginalMesh.colors;
     newMesh.subMeshCount = OriginalMesh.subMeshCount;
     newMesh.normals = normals ?? OriginalMesh.normals;

--- a/UnitySDK/Assets/TiltBrush/Scripts/Editor/EditorUtils.cs
+++ b/UnitySDK/Assets/TiltBrush/Scripts/Editor/EditorUtils.cs
@@ -426,7 +426,8 @@ public class EditorUtils {
     newMesh.colors = colors ?? OriginalMesh.colors;
     newMesh.subMeshCount = OriginalMesh.subMeshCount;
     newMesh.normals = normals ?? OriginalMesh.normals;
-    AssetDatabase.CreateAsset(newMesh, $"Assets/MeshToStrokes/{OriginalMesh.name}_submesh[{index}].asset");
+    string assetName = AssetDatabase.GenerateUniqueAssetPath($"Assets/MeshToStrokes/{OriginalMesh.name}_submesh[{index}].asset");
+    AssetDatabase.CreateAsset(newMesh, assetName);
     return newMesh;
   }
 

--- a/UnitySDK/Assets/TiltBrush/Scripts/Editor/EditorUtils.cs
+++ b/UnitySDK/Assets/TiltBrush/Scripts/Editor/EditorUtils.cs
@@ -55,16 +55,28 @@ public class EditorUtils {
     {
       foreach (var obj in selected)
       {
-        MeshFilter mf = obj.GetComponent<MeshFilter>();
-        MeshRenderer mr = mf.GetComponent<MeshRenderer>();
-        cancel = MeshToStroke(mf);
-        if (cancel)
+        try
         {
-          Undo.RevertAllInCurrentGroup();
-          break;
+          MeshFilter mf = obj.GetComponent<MeshFilter>();
+          if (mf == null) throw new MissingComponentException($"Missing MeshFilter on {obj.name}");
+
+          MeshRenderer mr = mf.GetComponent<MeshRenderer>();
+          if (mr == null) throw new MissingComponentException($"Missing MeshRenderer on {obj.name}");
+
+          cancel = MeshToStroke(mf);
+          if (cancel)
+          {
+            Undo.RevertAllInCurrentGroup();
+            break;
+          }
+
+          Undo.DestroyObjectImmediate(mf);
+          Undo.DestroyObjectImmediate(mr);
         }
-        Undo.DestroyObjectImmediate(mf);
-        Undo.DestroyObjectImmediate(mr);
+        catch (MissingComponentException ex)
+        {
+          Debug.LogError($"Error processing object {obj.name}: {ex.Message}");
+        }
       }
     }
     finally // since we call AssetDatabase.StartAssetEditing(), we must also call AssetDatabase.StopAssetEditing()

--- a/UnitySDK/Assets/TiltBrush/Scripts/Editor/EditorUtils.cs
+++ b/UnitySDK/Assets/TiltBrush/Scripts/Editor/EditorUtils.cs
@@ -239,6 +239,7 @@ public class EditorUtils {
           Vector2[] uv = new Vector2[vertexCount];
           Vector3[] normals = new Vector3[vertexCount];
           Color[] colors = new Color[vertexCount];
+          Vector3[] uv2_ = new Vector3[vertexCount];
 
 
           NativeArray<int>.Copy(allNewTriangles, startingIndexInTrianglesArray, trianglesForStroke, 0, triangleCount);
@@ -246,9 +247,9 @@ public class EditorUtils {
           Array.Copy(mesh.uv, startingIndexInVerticesArray, uv, 0, vertexCount);
           Array.Copy(mesh.normals, startingIndexInVerticesArray, normals, 0, vertexCount);
           Array.Copy(mesh.colors, startingIndexInVerticesArray, colors, 0, vertexCount);
+          Array.Copy(mesh.uv2, startingIndexInVerticesArray, uv2_, 0, vertexCount);
 
-
-          var newMesh_ = GetMeshSubset(mesh,trianglesForStroke,vertices, uv, uv2.ToArray(),normals, colors, strokeIndex);
+          var newMesh_ = GetMeshSubset(mesh,trianglesForStroke,vertices, uv, uv2_,normals, colors, strokeIndex);
 
           strokeGameObject.GetComponent<MeshFilter>().mesh = newMesh_;
           strokeIndex++;

--- a/UnitySDK/Assets/TiltBrush/Scripts/Editor/EditorUtils.cs
+++ b/UnitySDK/Assets/TiltBrush/Scripts/Editor/EditorUtils.cs
@@ -77,6 +77,10 @@ public class EditorUtils {
         {
           Debug.LogError($"Error processing object {obj.name}: {ex.Message}");
         }
+        catch (InvalidOperationException ex)
+        {
+          Debug.LogError($"Error processing object {obj.name}: {ex.Message}");
+        }
       }
     }
     finally // since we call AssetDatabase.StartAssetEditing(), we must also call AssetDatabase.StopAssetEditing()
@@ -98,7 +102,7 @@ public class EditorUtils {
 
       if (uv3.Count == 0)
       {
-        Debug.LogError($"Mesh ({mesh.name}) has no timestamps. Make sure the sketch was exported from Open Brush with ExportStrokeTimestamp = true");
+        throw new InvalidOperationException($"Mesh ({mesh.name}) has no timestamps. Make sure the sketch was exported from Open Brush with ExportStrokeTimestamp = true");
       }
       else
       {

--- a/UnitySDK/Assets/TiltBrush/Scripts/Editor/EditorUtils.cs
+++ b/UnitySDK/Assets/TiltBrush/Scripts/Editor/EditorUtils.cs
@@ -312,12 +312,12 @@ public class EditorUtils {
     }
   }
 
-  [MenuItem("Tilt Brush/Labs/Separate strokes by brush color")]
+  [MenuItem("Tilt Brush/Labs/Split mesh by color")]
   public static void ExplodeSketchByColor() {
     if (!EditorUtility.DisplayDialog ("Different Strokes", "Separate brush strokes of different colors into separate objects? \n* Note: This is an experimental feature!", "OK", "Cancel"))
       return;
     Undo.IncrementCurrentGroup();
-    Undo.SetCurrentGroupName("Separate sketch by color");
+    Undo.SetCurrentGroupName("Split mesh by color");
     List<GameObject> newSelection = new List<GameObject>();
     bool cancel = false;
 
@@ -327,7 +327,7 @@ public class EditorUtils {
       if (cancel) break;
       var obj = GameObject.Instantiate(o, o.transform.position, o.transform.rotation) as GameObject;
       obj.name = o.name + " (Separated)";
-      Undo.RegisterCreatedObjectUndo(obj, "Separate sketch by color");
+      Undo.RegisterCreatedObjectUndo(obj, "Split mesh by color");
       newSelection.Add(obj);
       int count = 0;
 
@@ -379,7 +379,7 @@ public class EditorUtils {
           var newObj = GameObject.Instantiate(m.gameObject, m.transform.position, m.transform.rotation) as GameObject;
           newObj.name = string.Format("{0} {1}", m.name, colorIndex);
           newObj.transform.SetParent(m.transform.parent, true);
-          Undo.RegisterCreatedObjectUndo(newObj, "Separate sketch by color");
+          Undo.RegisterCreatedObjectUndo(newObj, "Split mesh by color");
 
           // get the subset of triangles for this color and make a new mesh out of it. TODO: only use the vertices used by the triangles
           var newMesh = GetMeshSubset(mesh, colors[color].ToArray());
@@ -400,7 +400,7 @@ public class EditorUtils {
     EditorUtility.ClearProgressBar();
   }
 
-  [MenuItem("Tilt Brush/Labs/Separate strokes by brush color", true)]
+  [MenuItem("Tilt Brush/Labs/Split mesh by color", true)]
   public static bool ExplodeSketchByColorValidate() {
     // TODO: validate that selection is a model
     foreach (var o in Selection.gameObjects) {

--- a/UnitySDK/Assets/TiltBrush/Scripts/Jobs.meta
+++ b/UnitySDK/Assets/TiltBrush/Scripts/Jobs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9bacaf2e2cd544e438b720a1255efbe7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnitySDK/Assets/TiltBrush/Scripts/Jobs/TriangleArrayCopyJob.cs
+++ b/UnitySDK/Assets/TiltBrush/Scripts/Jobs/TriangleArrayCopyJob.cs
@@ -10,7 +10,7 @@ using UnityEngine;
 public struct TriangleArrayCopyJob : IJobParallelFor
 {
     [ReadOnly]
-    public NativeArray<Vector3> uv2;
+    public NativeArray<Vector3> uv3;
 
     [ReadOnly] public NativeArray<float> strokeIDs;
 
@@ -40,7 +40,7 @@ public struct TriangleArrayCopyJob : IJobParallelFor
         // we iterate the vertices
         for (int i = 0; i < originalTriangles.Length; i += 3)
         {
-            if (MathematicsUtils.AreFloatsEqual(targetStrokeID, uv2[originalTriangles[i]].x))
+            if (MathematicsUtils.AreFloatsEqual(targetStrokeID, uv3[originalTriangles[i]].x))
             {
                 triangles[startingIndex + triangleIndex] = vertexMap[originalTriangles[i]];
                 triangles[startingIndex + triangleIndex + 1] = vertexMap[originalTriangles[i+1]];

--- a/UnitySDK/Assets/TiltBrush/Scripts/Jobs/TriangleArrayCopyJob.cs
+++ b/UnitySDK/Assets/TiltBrush/Scripts/Jobs/TriangleArrayCopyJob.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using TiltBrushToolkit;
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Jobs;
+using UnityEngine;
+
+[BurstCompile]
+public struct TriangleArrayCopyJob : IJobParallelFor
+{
+    [ReadOnly]
+    public NativeArray<Vector3> uv2;
+
+    [ReadOnly] public NativeArray<float> strokeIDs;
+
+    [ReadOnly] public NativeArray<int> originalTriangles;
+
+    [ReadOnly] public NativeArray<int> triangleCounts;
+
+    // map a vertex index in mesh.vertices to the vertex index in newMesh.vertices array
+    [ReadOnly] public NativeArray<int> vertexMap;
+
+    // output: this contains all the triangles, in contiguous memory
+    [NativeDisableParallelForRestriction]
+    public NativeArray<int> triangles;
+
+    // index is the nth stroke
+    public void Execute(int index)
+    {
+        float targetStrokeID = strokeIDs[index];
+
+        int startingIndex = 0;
+        for (int i = 0; i < index; i++)
+        {
+            startingIndex += (triangleCounts[i]);
+        }
+
+        int triangleIndex = 0;
+        // we iterate the vertices
+        for (int i = 0; i < originalTriangles.Length; i += 3)
+        {
+            if (MathematicsUtils.AreFloatsEqual(targetStrokeID, uv2[originalTriangles[i]].x))
+            {
+                triangles[startingIndex + triangleIndex] = vertexMap[originalTriangles[i]];
+                triangles[startingIndex + triangleIndex + 1] = vertexMap[originalTriangles[i+1]];
+                triangles[startingIndex + triangleIndex + 2] = vertexMap[originalTriangles[i+2]];
+                triangleIndex += 3;
+            }
+        }
+
+    }
+
+
+}

--- a/UnitySDK/Assets/TiltBrush/Scripts/Jobs/TriangleArrayCopyJob.cs.meta
+++ b/UnitySDK/Assets/TiltBrush/Scripts/Jobs/TriangleArrayCopyJob.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5eae16851b7fec049ba22cee6149a581
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnitySDK/Assets/TiltBrush/Scripts/Jobs/TriangleCountJob.cs
+++ b/UnitySDK/Assets/TiltBrush/Scripts/Jobs/TriangleCountJob.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using TiltBrushToolkit;
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Jobs;
+using UnityEngine;
+
+[BurstCompile]
+public struct TriangleCountJob : IJobParallelFor
+{
+    [ReadOnly]
+    public NativeArray<int> triangles;
+
+    [ReadOnly]
+    public NativeArray<float> strokeIDs;
+
+    [ReadOnly]
+    public NativeArray<Vector3> uv2;
+
+    public NativeArray<int> triangleCounts; // Output: The count of triangles for each stroke
+
+    // index is the strokeID index
+    public void Execute(int index)
+    {
+
+        float targetStrokeID = strokeIDs[index];
+        for (int i = 0; i < triangles.Length; i += 3)
+        {
+            if (MathematicsUtils.AreFloatsEqual(targetStrokeID, uv2[triangles[i]].x))
+            {
+                triangleCounts[index] += 3;
+            }
+        }
+
+    }
+
+}

--- a/UnitySDK/Assets/TiltBrush/Scripts/Jobs/TriangleCountJob.cs
+++ b/UnitySDK/Assets/TiltBrush/Scripts/Jobs/TriangleCountJob.cs
@@ -16,7 +16,7 @@ public struct TriangleCountJob : IJobParallelFor
     public NativeArray<float> strokeIDs;
 
     [ReadOnly]
-    public NativeArray<Vector3> uv2;
+    public NativeArray<Vector3> uv3;
 
     public NativeArray<int> triangleCounts; // Output: The count of triangles for each stroke
 
@@ -27,7 +27,7 @@ public struct TriangleCountJob : IJobParallelFor
         float targetStrokeID = strokeIDs[index];
         for (int i = 0; i < triangles.Length; i += 3)
         {
-            if (MathematicsUtils.AreFloatsEqual(targetStrokeID, uv2[triangles[i]].x))
+            if (MathematicsUtils.AreFloatsEqual(targetStrokeID, uv3[triangles[i]].x))
             {
                 triangleCounts[index] += 3;
             }

--- a/UnitySDK/Assets/TiltBrush/Scripts/Jobs/TriangleCountJob.cs.meta
+++ b/UnitySDK/Assets/TiltBrush/Scripts/Jobs/TriangleCountJob.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 43ff59cef122a2b499999973ea9e7428
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnitySDK/Assets/TiltBrush/Scripts/Jobs/VertexMapJob.cs
+++ b/UnitySDK/Assets/TiltBrush/Scripts/Jobs/VertexMapJob.cs
@@ -12,7 +12,7 @@ public struct VertexMapJob : IJobParallelFor
 
     [ReadOnly] public NativeArray<float> strokeIDs;
 
-    [ReadOnly] public NativeArray<Vector3> uv2;
+    [ReadOnly] public NativeArray<Vector3> uv3;
 
     [NativeDisableParallelForRestriction]
     public NativeArray<int> vertexMap;
@@ -26,11 +26,11 @@ public struct VertexMapJob : IJobParallelFor
         bool lookingForStartingIndex = true;
 
 
-        for (int i = 0; i < uv2.Length; i++)
+        for (int i = 0; i < uv3.Length; i++)
         {
             if (lookingForStartingIndex)
             {
-                if (MathematicsUtils.AreFloatsEqual(uv2[i].x, strokeId))
+                if (MathematicsUtils.AreFloatsEqual(uv3[i].x, strokeId))
                 {
                     startingVertexIndex = i;
                     lookingForStartingIndex = false;
@@ -39,7 +39,7 @@ public struct VertexMapJob : IJobParallelFor
             else
             {
                 // we're done
-                if (!MathematicsUtils.AreFloatsEqual(uv2[i].x, strokeId))
+                if (!MathematicsUtils.AreFloatsEqual(uv3[i].x, strokeId))
                 {
                     break;
                 }

--- a/UnitySDK/Assets/TiltBrush/Scripts/Jobs/VertexMapJob.cs
+++ b/UnitySDK/Assets/TiltBrush/Scripts/Jobs/VertexMapJob.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using TiltBrushToolkit;
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Jobs;
+using UnityEngine;
+
+[BurstCompile]
+public struct VertexMapJob : IJobParallelFor
+{
+
+    [ReadOnly] public NativeArray<float> strokeIDs;
+
+    [ReadOnly] public NativeArray<Vector3> uv2;
+
+    [NativeDisableParallelForRestriction]
+    public NativeArray<int> vertexMap;
+
+    public void Execute(int index)
+    {
+        float strokeId = strokeIDs[index];
+
+        int startingVertexIndex = 0;
+
+        bool lookingForStartingIndex = true;
+
+
+        for (int i = 0; i < uv2.Length; i++)
+        {
+            if (lookingForStartingIndex)
+            {
+                if (MathematicsUtils.AreFloatsEqual(uv2[i].x, strokeId))
+                {
+                    startingVertexIndex = i;
+                    lookingForStartingIndex = false;
+                }
+            }
+            else
+            {
+                // we're done
+                if (!MathematicsUtils.AreFloatsEqual(uv2[i].x, strokeId))
+                {
+                    break;
+                }
+
+                vertexMap[i] = i - startingVertexIndex;
+            }
+        }
+
+
+    }
+}

--- a/UnitySDK/Assets/TiltBrush/Scripts/Jobs/VertexMapJob.cs.meta
+++ b/UnitySDK/Assets/TiltBrush/Scripts/Jobs/VertexMapJob.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a9cc43d4fc33544488e220e3ee24b36
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UnitySDK/Assets/TiltBrush/Scripts/MathematicsUtils.cs
+++ b/UnitySDK/Assets/TiltBrush/Scripts/MathematicsUtils.cs
@@ -1,0 +1,16 @@
+using Unity.Mathematics;
+
+namespace TiltBrushToolkit
+{
+
+    // utils for working with Unity.Mathematics
+    public class MathematicsUtils
+    {
+
+        public static bool AreFloatsEqual(float a, float b, float epsilon = 0.00001f)
+        {
+            return math.abs(a - b) < epsilon;
+        }
+
+    }
+}

--- a/UnitySDK/Assets/TiltBrush/Scripts/MathematicsUtils.cs.meta
+++ b/UnitySDK/Assets/TiltBrush/Scripts/MathematicsUtils.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 2c1e255df445465d91a4d06af9b32d3a
+timeCreated: 1734724080

--- a/UnitySDK/Assets/TiltBrush/Scripts/TiltBrushToolkitRuntime.asmdef
+++ b/UnitySDK/Assets/TiltBrush/Scripts/TiltBrushToolkitRuntime.asmdef
@@ -1,14 +1,17 @@
 {
     "name": "TiltBrushToolkitRuntime",
     "references": [
-        "TiltBrushToolkitThirdParty"
+        "TiltBrushToolkitThirdParty",
+        "Unity.Mathematics",
+        "Unity.Burst"
     ],
-    "optionalUnityReferences": [],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": true,
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/UnitySDK/Packages/manifest.json
+++ b/UnitySDK/Packages/manifest.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "com.unity.burst": "1.4.11",
     "com.unity.collab-proxy": "1.2.16",
     "com.unity.ide.rider": "1.2.1",
     "com.unity.ide.vscode": "1.2.5",

--- a/UnitySDK/Packages/packages-lock.json
+++ b/UnitySDK/Packages/packages-lock.json
@@ -1,5 +1,14 @@
 {
   "dependencies": {
+    "com.unity.burst": {
+      "version": "1.4.11",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.mathematics": "1.2.1"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.collab-proxy": {
       "version": "1.2.16",
       "depth": 0,
@@ -30,6 +39,13 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.mathematics": {
+      "version": "1.2.1",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
     "com.unity.test-framework": {
       "version": "1.1.33",
       "depth": 0,
@@ -55,9 +71,9 @@
       "depth": 0,
       "source": "registry",
       "dependencies": {
+        "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.director": "1.0.0",
         "com.unity.modules.animation": "1.0.0",
-        "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.particlesystem": "1.0.0"
       },
       "url": "https://packages.unity.com"


### PR DESCRIPTION
This PR implements the "Mesh to Strokes" tool that allows the Unity developer to separate a mesh containing Open Brush timestamp data into individual strokes.

**Motivation**
- When exporting a sketch from Open Brush, the exporter will group strokes by brush type. This means that the Unity developer cannot work with the original strokes in their Unity project. 

- Being able to separate a mesh into its original strokes is also helpful when working with the upcoming Sketch Playback feature that allows animating sketches to be drawn using the timestamp data.

**How this PR addresses the issue**

- The Open Brush exporter stores vertex timestamp data in UV3 channels, encoded as a vector3 where:

  - x: Start time of the stroke (ms).
  - y: End time of the stroke (ms).
  - z: Time this vertex was drawn (ms).

- The Unity Jobs system is used to create the mesh data arrays for each new mesh efficiently.

- New meshes are saved as assets in `Assets/MeshToStrokes/` (to prevent mesh data from getting saved in the scene file)

**Profiling on Windows 10, Intel Core i5-9600K 3.7GHz w/6 cores, 16GB RAM:**

| Case                                | Time      |
|-------------------------------------|-----------|
|  5 meshes (each mesh: 50k vertices, 10 strokes) | ~4000ms |
|  1 mesh (50k vertices, 150 strokes) | ~1500ms   |
|  1 mesh (1k vertices, 20 strokes)       | ~800ms    |
|  1 mesh (50k vertices, 50 strokes)      | ~1000ms   |
| 50 meshes (each mesh: 50k vertices, 10 strokes) | ~7000ms

**Manual Tests**

| Scenario                             | Expected | Status     |
|-------------------------------------|-----------|-----------|
|  **Default:** Selection contains only valid GameObjects (e.g have MeshFilter with uv3 not empty) | Each selected GameObject's MeshRenderer and MeshFilter is removed, " (separated)" is added to the name, and it becomes a parent of children GameObjects, that each have a part of the original mesh, separated by StrokeIDs. All the vertices of a single child mesh have the same uv3.x  | ✅&nbsp;&nbsp;&nbsp; |
|  Mesh with uv2 data used by Brush shader (e.g Smoke, Electricity) | uv2 data is copied to the children mesh, and brush shaders continue working properly  | ✅ |
| Selection contains GameObject with mesh that has no uv3 | Error message: "Mesh ({mesh.name}) has no timestamps..." is logged to the console | ✅ |
|  GameObject with mesh that has uv3 full of Vector3.zero (i.e. invalid timestamp data)  | No Error. The MeshRenderer and MeshFilter are removed, " (separated)" is added to the name, and it becomes a parent of a single GameObject that has the entire mesh. | ✅| 
|  Only Invalid Selections (e.g. GameObjects that have no meshes)   | Error message "Missing MeshFilter on ..." is logged to the console | ✅    | 
|  Valid and Invalid selections  | Valid selections are processed as expected, invalid selections are skipped and error messages are logged for each one| ✅ |

**Making this work with the new SDK**

Making this same feature for the newer Unity SDK (https://github.com/icosa-foundation/open-brush-unity-tools), performance can be improved by using Unity's Advanced Mesh API introduced in Unity 2020.1. We can also use Unity.Collections, which gives us more Native datastructures to work with in Jobs. (we can get the job done with just NativeArray, but types like NativeHashSet and NativeList would be convenient) The reason why Unity.Collections is not used in this project, is because it uses com.unity.nuget.newtonsoft which collides with Net.Json.

https://github.com/user-attachments/assets/914f183d-98ac-4191-af3c-903f83bf290e



















