### PR TITLE
fix inconsistent folder paths in asset creation

### DIFF
--- a/UnitySDK/Assets/TiltBrush/Scripts/Editor/EditorUtils.cs
+++ b/UnitySDK/Assets/TiltBrush/Scripts/Editor/EditorUtils.cs
@@ -45,7 +45,7 @@ public class EditorUtils {
 
     AssetDatabase.StartAssetEditing();
 
-    if (!AssetDatabase.IsValidFolder("Assets/SplitMeshByStroke"))
+    if (!AssetDatabase.IsValidFolder($"Assets/{m_SplitMeshByStrokeDirectoryName}"))
     {
       AssetDatabase.CreateFolder("Assets","SplitMeshByStroke");
     }
@@ -451,7 +451,7 @@ public class EditorUtils {
     newMesh.colors = colors ?? OriginalMesh.colors;
     newMesh.subMeshCount = OriginalMesh.subMeshCount;
     newMesh.normals = normals ?? OriginalMesh.normals;
-    string assetName = AssetDatabase.GenerateUniqueAssetPath($"Assets/MeshToStrokes/{OriginalMesh.name}_submesh[{index}].asset");
+    string assetName = AssetDatabase.GenerateUniqueAssetPath($"Assets/{m_SplitMeshByStrokeDirectoryName}/{OriginalMesh.name}_submesh[{index}].asset");
     AssetDatabase.CreateAsset(newMesh, assetName);
     return newMesh;
   }
@@ -460,6 +460,7 @@ public class EditorUtils {
 
   #endregion
 
+  public static string m_SplitMeshByStrokeDirectoryName = "SplitMeshByStroke";
   public static string m_TiltBrushDirectoryName = "TiltBrush";
   static string m_TiltBrushDirectory = "";
   public static string TiltBrushDirectory {


### PR DESCRIPTION
When the "Split mesh by stroke" tool's name was changed from "Mesh to strokes" to "Split mesh by stroke", the AssetDataBase.CreateAsset() in GetMeshSubset() wasn't updated to use the new folder name. The tool doesn't work currently as a result. 